### PR TITLE
Changed API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,23 +17,31 @@ type Msg
     = NoOp
     ..
     | OnDrop String Int
-    | DnDMsg (DnD.Msg String Msg)
+    | DnDMsg (DnD.Msg String Int)
+
+
+type alias Model =
+    { ...
+    , draggable : DnD.Draggable String Int
+    }
 
 
 dnd = DnD.init DnDMsg OnDrop
-type alias Model =
+
+
+model =
     { ...
-    , draggable = dnd.model
+    , draggable : dnd.model
     }
 ```
 
-Subscriptions alow you to get drop event.
+Subscriptions allow you to get drop event.
 ```elm
 subscriptions : Model -> Sub Msg
 subscriptions model =
     dnd.subscriptions model.draggable
 ```
-View wrapper for draggable object, you could drag object wraped by this helper
+View wrapper for draggable object, you could drag object wrapped by this helper
 ```elm
 draggable
     : (Html.Attribute Msg)

--- a/README.md
+++ b/README.md
@@ -4,23 +4,23 @@ This library allows you to build great UI with drag-and-drop simple.
 It is abstracting you from mouse events and other low-level stuff.  
 You can operate high-level things such as draggable and droppable areas.  
 
-The idea of package API is you should be able to wrap elements with `draggable meta` to add an ability to drag it.  
+The idea of package API is you should be able to wrap elements with `draggable dragMeta` to add an ability to drag it.  
 The dragging object will get some meta information.  
-Also, you could wrap another element with `droppable Drop`,  
-so if you drop element over that element, the message `Drop meta` will be invoked.  
+Also, you could wrap another element with `droppable dropMeta`,  
+so if you drop element over that element, the message `OnDrop dragMeta dropMeta` will be invoked.  
 
 At first, you need to initialize draggable state and function.  
-`DnD.init` helper returns initModel, subscription, draggable and droppable functions for your message wrapper.  
+`DnD.init` helper returns initModel, subscription, draggable and droppable functions for your message wrapper and onDrop message.
 
 ```elm
 type Msg
     = NoOp
     ..
-    | Dropped String
+    | OnDrop String Int
     | DnDMsg (DnD.Msg String Msg)
 
 
-dnd = DnD.init DnDMsg
+dnd = DnD.init DnDMsg OnDrop
 type alias Model =
     { ...
     , draggable = dnd.model
@@ -39,18 +39,16 @@ draggable
     : (Html.Attribute Msg)
     -> List (Html Msg)
     -> Html Msg
-draggable =  dnd.draggable meta
+draggable =  dnd.draggable dragMeta
 ```
 View helper for droppable area, you could drop object to this area,
-after that your on `Drop meta` message will be invoked.
+after that your on `OnDrop` message will be invoked.
 ```elm
 droppable
   : (Html.Attribute Msg)
   -> List (Html Msg)
   -> Html Msg
-droppable = dnd.droppable Dropped
+droppable = dnd.droppable dropMeta
 ```
 
 You can find examples [here](https://github.com/ir4y/elm-dnd/tree/master/example/src).  
-
-

--- a/example/elm-package.json
+++ b/example/elm-package.json
@@ -4,7 +4,7 @@
     "repository": "https://github.com/user/project.git",
     "license": "BSD3",
     "source-directories": [
-        "..",
+        "../src",
         "src"
     ],
     "exposed-modules": [],

--- a/example/src/Box.elm
+++ b/example/src/Box.elm
@@ -16,7 +16,7 @@ main =
 
 
 dnd =
-    DnD.init DnDMsg
+    DnD.init DnDMsg (always Dropped)
 
 
 subscriptions : Model -> Sub Msg
@@ -27,7 +27,7 @@ subscriptions model =
 
 
 type alias Model =
-    { draggable : DnD.Draggable Int Msg
+    { draggable : DnD.Draggable () Int Msg
     , count : Int
     }
 
@@ -39,7 +39,7 @@ init =
 
 type Msg
     = Dropped Int
-    | DnDMsg (DnD.Msg Int Msg)
+    | DnDMsg (DnD.Msg () Int Msg)
 
 
 update : Msg -> Model -> ( Model, Cmd.Cmd Msg )
@@ -73,15 +73,15 @@ view model =
                 ]
             ]
             [ dnd.draggable (model.count + 1) [] [ dragged model.count ] ]
-        , dnd.droppable Dropped
+        , dnd.droppable ()
             [ style
                 [ "width" => "49%"
                 , "min-height" => "200px"
                 , "float" => "right"
                 , "border" => "1px solid black"
                 , "background-color"
-                    => case DnD.atDroppable model.draggable of
-                        Just (Dropped _) ->
+                    => case DnD.getDropMeta model.draggable of
+                        Just _ ->
                             "cyan"
 
                         _ ->

--- a/example/src/Box.elm
+++ b/example/src/Box.elm
@@ -27,7 +27,7 @@ subscriptions model =
 
 
 type alias Model =
-    { draggable : DnD.Draggable () Int Msg
+    { draggable : DnD.Draggable () Int
     , count : Int
     }
 
@@ -39,7 +39,7 @@ init =
 
 type Msg
     = Dropped Int
-    | DnDMsg (DnD.Msg () Int Msg)
+    | DnDMsg (DnD.Msg () Int)
 
 
 update : Msg -> Model -> ( Model, Cmd.Cmd Msg )

--- a/example/src/DragOnly.elm
+++ b/example/src/DragOnly.elm
@@ -16,7 +16,7 @@ main =
 
 
 dnd =
-    DnD.init DnDMsg
+    DnD.init DnDMsg never
 
 
 subscriptions : Model -> Sub Msg
@@ -27,7 +27,7 @@ subscriptions model =
 
 
 type alias Model =
-    DnD.Draggable String Msg
+    DnD.Draggable Never String Msg
 
 
 init : ( Model, Cmd Msg )
@@ -36,7 +36,7 @@ init =
 
 
 type Msg
-    = DnDMsg (DnD.Msg String Msg)
+    = DnDMsg (DnD.Msg Never String Msg)
 
 
 update : Msg -> Model -> ( Model, Cmd.Cmd Msg )

--- a/example/src/DragOnly.elm
+++ b/example/src/DragOnly.elm
@@ -27,7 +27,7 @@ subscriptions model =
 
 
 type alias Model =
-    DnD.Draggable Never String Msg
+    DnD.Draggable Never String
 
 
 init : ( Model, Cmd Msg )
@@ -36,7 +36,7 @@ init =
 
 
 type Msg
-    = DnDMsg (DnD.Msg Never String Msg)
+    = DnDMsg (DnD.Msg Never String)
 
 
 update : Msg -> Model -> ( Model, Cmd.Cmd Msg )

--- a/example/src/SortingList.elm
+++ b/example/src/SortingList.elm
@@ -16,7 +16,7 @@ main =
 
 
 dnd =
-    DnD.init DnDMsg
+    DnD.init DnDMsg Dropped
 
 
 subscriptions : Model -> Sub Msg
@@ -27,11 +27,11 @@ subscriptions model =
 
 
 type alias Draggable =
-    DnD.Draggable ( Int, String ) Msg
+    DnD.Draggable Int ( Int, String ) Msg
 
 
 type alias DraggableMsg =
-    DnD.Msg ( Int, String ) Msg
+    DnD.Msg Int ( Int, String ) Msg
 
 
 type alias Item =
@@ -192,15 +192,15 @@ view model =
 
 droppable index draggableModel =
     dnd.droppable
-        (Dropped index)
+        index
         [ style
             [ "width" => "40px"
             , "height" => "20px"
             , "float" => "left"
             , "background-color"
                 => if
-                    case DnD.atDroppable draggableModel of
-                        Just (Dropped to _) ->
+                    case DnD.getDropMeta draggableModel of
+                        Just to ->
                             to == index
 
                         _ ->

--- a/example/src/SortingList.elm
+++ b/example/src/SortingList.elm
@@ -27,11 +27,11 @@ subscriptions model =
 
 
 type alias Draggable =
-    DnD.Draggable Int ( Int, String ) Msg
+    DnD.Draggable Int ( Int, String )
 
 
 type alias DraggableMsg =
-    DnD.Msg Int ( Int, String ) Msg
+    DnD.Msg Int ( Int, String )
 
 
 type alias Item =

--- a/example/src/Table.elm
+++ b/example/src/Table.elm
@@ -44,8 +44,8 @@ type alias Item =
 type alias Model =
     { left : List Item
     , right : List Item
-    , draggableLeft : DnD.Draggable () Item Msg
-    , draggableRight : DnD.Draggable () Item Msg
+    , draggableLeft : DnD.Draggable () Item
+    , draggableRight : DnD.Draggable () Item
     }
 
 
@@ -63,8 +63,8 @@ init =
 type Msg
     = DropToRight Item
     | DropToLeft Item
-    | DnDMsgLeftColumn (DnD.Msg () Item Msg)
-    | DnDMsgRightColumn (DnD.Msg () Item Msg)
+    | DnDMsgLeftColumn (DnD.Msg () Item)
+    | DnDMsgRightColumn (DnD.Msg () Item)
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )

--- a/example/src/Table.elm
+++ b/example/src/Table.elm
@@ -16,11 +16,11 @@ main =
 
 
 dndLeft =
-    DnD.init DnDMsgLeftColumn
+    DnD.init DnDMsgLeftColumn (always DropToLeft)
 
 
 dndRigth =
-    DnD.init DnDMsgRightColumn
+    DnD.init DnDMsgRightColumn (always DropToRight)
 
 
 subscriptions : Model -> Sub Msg
@@ -44,8 +44,8 @@ type alias Item =
 type alias Model =
     { left : List Item
     , right : List Item
-    , draggableLeft : DnD.Draggable Item Msg
-    , draggableRight : DnD.Draggable Item Msg
+    , draggableLeft : DnD.Draggable () Item Msg
+    , draggableRight : DnD.Draggable () Item Msg
     }
 
 
@@ -63,8 +63,8 @@ init =
 type Msg
     = DropToRight Item
     | DropToLeft Item
-    | DnDMsgLeftColumn (DnD.Msg Item Msg)
-    | DnDMsgRightColumn (DnD.Msg Item Msg)
+    | DnDMsgLeftColumn (DnD.Msg () Item Msg)
+    | DnDMsgRightColumn (DnD.Msg () Item Msg)
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
@@ -110,14 +110,14 @@ update_ msg model =
 view : Model -> Html Msg
 view model =
     div [ style [ "width" => "100%" ] ]
-        [ dndLeft.droppable DropToLeft
+        [ dndLeft.droppable ()
             [ style
                 [ "width" => "50%"
                 , "min-height" => "200px"
                 , "float" => "left"
                 , "background-color"
-                    => case DnD.atDroppable model.draggableLeft of
-                        Just (DropToLeft _) ->
+                    => case DnD.getDropMeta model.draggableLeft of
+                        Just _ ->
                             "cyan"
 
                         _ ->
@@ -128,14 +128,14 @@ view model =
                 (\item -> dndRigth.draggable item [] [ box item ])
                 model.left
             )
-        , dndRigth.droppable DropToRight
+        , dndRigth.droppable ()
             [ style
                 [ "width" => "50%"
                 , "min-height" => "200px"
                 , "float" => "right"
                 , "background-color"
-                    => case DnD.atDroppable model.draggableRight of
-                        Just (DropToRight _) ->
+                    => case DnD.getDropMeta model.draggableRight of
+                        Just _ ->
                             "cyan"
 
                         _ ->

--- a/src/DnD.elm
+++ b/src/DnD.elm
@@ -58,7 +58,7 @@ type alias Model =
     }
 ```
 -}
-type Draggable dropMeta dragMeta m
+type Draggable dropMeta dragMeta
     = Draggable
         (Maybe
             { dragMeta : dragMeta
@@ -73,8 +73,8 @@ The type of init function result.
 See `init` for more information.
 -}
 type alias DraggableInit dropMeta dragMeta m =
-    { model : Draggable dropMeta dragMeta m
-    , subscriptions : Draggable dropMeta dragMeta m -> Sub m
+    { model : Draggable dropMeta dragMeta
+    , subscriptions : Draggable dropMeta dragMeta -> Sub m
     , draggable : dragMeta -> List (Html.Attribute m) -> List (Html m) -> Html m
     , droppable : dropMeta -> List (Html.Attribute m) -> List (Html m) -> Html m
     }
@@ -124,7 +124,7 @@ droppable
 droppable = dnd.droppable Dropped
 ```
 -}
-init : (Msg dropMeta dragMeta m -> m) -> (dropMeta -> dragMeta -> m) -> DraggableInit dropMeta dragMeta m
+init : (Msg dropMeta dragMeta -> m) -> (dropMeta -> dragMeta -> m) -> DraggableInit dropMeta dragMeta m
 init wrap onDrop =
     { model = Draggable Nothing
     , subscriptions = subscriptions wrap onDrop
@@ -153,7 +153,7 @@ DnD.droppable Dropped
    []
 ```
 -}
-getDropMeta : Draggable dropMeta dragMeta m -> Maybe dropMeta
+getDropMeta : Draggable dropMeta dragMeta -> Maybe dropMeta
 getDropMeta (Draggable draggable) =
     draggable
         |> Maybe.andThen .dropMeta
@@ -171,7 +171,7 @@ elements = model.elements
         )
 ```
 -}
-getDragMeta : Draggable dropMeta dragMeta m -> Maybe dragMeta
+getDragMeta : Draggable dropMeta dragMeta -> Maybe dragMeta
 getDragMeta (Draggable draggable) =
     draggable
         |> Maybe.map .dragMeta
@@ -184,7 +184,7 @@ type Msg
     | DnDMsg (DnD.Msg Int Msg)
 ```
 -}
-type Msg dropMeta dragMeta m
+type Msg dropMeta dragMeta
     = DragStart dragMeta Mouse.Position
     | Dragging Mouse.Position
     | DragEnd Mouse.Position
@@ -192,7 +192,7 @@ type Msg dropMeta dragMeta m
     | LeaveDroppable
 
 
-subscriptions : (Msg dropMeta dragMeta m -> m) -> (dropMeta -> dragMeta -> m) -> Draggable dropMeta dragMeta m -> Sub m
+subscriptions : (Msg dropMeta dragMeta -> m) -> (dropMeta -> dragMeta -> m) -> Draggable dropMeta dragMeta -> Sub m
 subscriptions wrap onDrop (Draggable model) =
     case model of
         Nothing ->
@@ -228,7 +228,7 @@ update msg model =
                     = DnD.update msg model.draggable }
 ``
 -}
-update : Msg dropMeta dragMeta m -> Draggable dropMeta dragMeta m -> Draggable dropMeta dragMeta m
+update : Msg dropMeta dragMeta -> Draggable dropMeta dragMeta -> Draggable dropMeta dragMeta
 update msg (Draggable model) =
     case msg of
         DragStart dragMeta xy ->
@@ -258,7 +258,7 @@ update msg (Draggable model) =
                 |> Draggable
 
 
-draggable : (Msg dropMeta dragMeta m -> m) -> dragMeta -> List (Html.Attribute m) -> List (Html m) -> Html m
+draggable : (Msg dropMeta dragMeta -> m) -> dragMeta -> List (Html.Attribute m) -> List (Html m) -> Html m
 draggable wrap meta attrs html =
     div
         ([ onWithOptions "mousedown"
@@ -272,7 +272,7 @@ draggable wrap meta attrs html =
         html
 
 
-droppable : (Msg dropMeta dragMeta m -> m) -> dropMeta -> List (Html.Attribute m) -> List (Html m) -> Html m
+droppable : (Msg dropMeta dragMeta -> m) -> dropMeta -> List (Html.Attribute m) -> List (Html m) -> Html m
 droppable wrap dropMeta attrs html =
     div
         (attrs
@@ -314,7 +314,7 @@ DnD.dragged
   box
 ```
 -}
-dragged : Draggable dropMeta dragMeta m -> (dragMeta -> Html m) -> Html m
+dragged : Draggable dropMeta dragMeta -> (dragMeta -> Html m) -> Html m
 dragged (Draggable model) view =
     model
         |> Maybe.map (\{ dragMeta, position } -> div [ draggedStyle position ] [ view dragMeta ])

--- a/src/DnD.elm
+++ b/src/DnD.elm
@@ -3,8 +3,8 @@ module DnD
         ( Draggable
         , Msg
         , DraggableInit
-        , atDroppable
-        , getMeta
+        , getDropMeta
+        , getDragMeta
         , init
         , update
         , dragged
@@ -15,18 +15,18 @@ This library allows you to build great UI with drag-and-drop simple.
 It is abstracting you from mouse events and other low-level staff.
 You can operate high-level things such as draggable and droppable areas.
 
-The idea of package API is you should be able to wrap elements with `draggable meta` to add an ability to drag it.
+The idea of package API is you should be able to wrap elements with `draggable dragMeta` to add an ability to drag it.
 The dragged object will get some meta information.
-Also, you could wrap another element with `droppable OnDrop`,
-so if you drop element over that element, the message `OnDrop meta` will be fired.
+Also, you could wrap another element with `droppable dropMeta`,
+so if you drop element over that element, the message `OnDrop dropMeta dragMeta` will be fired.
 
 You can find examples [here](https://github.com/ir4y/elm-dnd/tree/master/example/src).
 
 # Draggable types and its constructor
 @docs DraggableInit, Draggable, init
 
-# Helpers to get information about draggable object
-@docs atDroppable, getMeta
+# Helpers to get information about draggable and droppable object
+@docs getDropMeta, getDragMeta
 
 # Message type
 @docs Msg
@@ -58,12 +58,12 @@ type alias Model =
     }
 ```
 -}
-type Draggable a m
+type Draggable dropMeta dragMeta m
     = Draggable
         (Maybe
-            { meta : a
+            { dragMeta : dragMeta
             , position : Mouse.Position
-            , atDroppable : Maybe (a -> m)
+            , dropMeta : Maybe dropMeta
             }
         )
 
@@ -72,11 +72,11 @@ type Draggable a m
 The type of init function result.
 See `init` for more information.
 -}
-type alias DraggableInit a m =
-    { model : Draggable a m
-    , subscriptions : Draggable a m -> Sub m
-    , draggable : a -> List (Html.Attribute m) -> List (Html m) -> Html m
-    , droppable : (a -> m) -> List (Html.Attribute m) -> List (Html m) -> Html m
+type alias DraggableInit dropMeta dragMeta m =
+    { model : Draggable dropMeta dragMeta m
+    , subscriptions : Draggable dropMeta dragMeta m -> Sub m
+    , draggable : dragMeta -> List (Html.Attribute m) -> List (Html m) -> Html m
+    , droppable : dropMeta -> List (Html.Attribute m) -> List (Html m) -> Html m
     }
 
 
@@ -124,17 +124,17 @@ droppable
 droppable = dnd.droppable Dropped
 ```
 -}
-init : (Msg a m -> m) -> DraggableInit a m
-init wrap =
+init : (Msg dropMeta dragMeta m -> m) -> (dropMeta -> dragMeta -> m) -> DraggableInit dropMeta dragMeta m
+init wrap onDrop =
     { model = Draggable Nothing
-    , subscriptions = subscriptions wrap
+    , subscriptions = subscriptions wrap onDrop
     , draggable = draggable wrap
     , droppable = droppable wrap
     }
 
 
 {-|
-Helper that return you a message that will be invoked.
+Helper that return you a dropMeta that will be used
 if an object will be dropped at the current area.
 It is useful to check is it area allow you to drop an object and highlight it for example.
 ```
@@ -142,8 +142,8 @@ DnD.droppable Dropped
   DnDMsg
    [ style
      [ "background-color"
-       => case DnD.atDroppable model.draggable of
-         Just (Dropped _) ->
+       => case DnD.getDropMeta model.draggable of
+         Just _ ->
            "cyan"
 
          _ ->
@@ -153,14 +153,10 @@ DnD.droppable Dropped
    []
 ```
 -}
-atDroppable : Draggable a m -> Maybe m
-atDroppable (Draggable draggable) =
+getDropMeta : Draggable dropMeta dragMeta m -> Maybe dropMeta
+getDropMeta (Draggable draggable) =
     draggable
-        |> Maybe.andThen
-            (\d ->
-                d.atDroppable
-                    |> Maybe.map (\f -> f d.meta)
-            )
+        |> Maybe.andThen .dropMeta
 
 
 {-|
@@ -170,15 +166,15 @@ You can use it to remove draggable object from the list
 elements = model.elements
     |> List.filter
         (e -> model.draggable
-            |>  getMeta
+            |>  getDragMeta
             |> Maybe.map (meta -> meta.id /= e.id )
         )
 ```
 -}
-getMeta : Draggable a m -> Maybe a
-getMeta (Draggable draggable) =
+getDragMeta : Draggable dropMeta dragMeta m -> Maybe dragMeta
+getDragMeta (Draggable draggable) =
     draggable
-        |> Maybe.map .meta
+        |> Maybe.map .dragMeta
 
 
 {-| Inner messages, you should pass them to DnD.update at your update function.
@@ -188,26 +184,26 @@ type Msg
     | DnDMsg (DnD.Msg Int Msg)
 ```
 -}
-type Msg a m
-    = DragStart a Mouse.Position
+type Msg dropMeta dragMeta m
+    = DragStart dragMeta Mouse.Position
     | Dragging Mouse.Position
     | DragEnd Mouse.Position
-    | EnterDroppable (a -> m)
+    | EnterDroppable dropMeta
     | LeaveDroppable
 
 
-subscriptions : (Msg a m -> m) -> Draggable a m -> Sub m
-subscriptions wrap (Draggable model) =
+subscriptions : (Msg dropMeta dragMeta m -> m) -> (dropMeta -> dragMeta -> m) -> Draggable dropMeta dragMeta m -> Sub m
+subscriptions wrap onDrop (Draggable model) =
     case model of
         Nothing ->
             Sub.none
 
         Just drag ->
-            case drag.atDroppable of
-                Just onDrop ->
+            case drag.dropMeta of
+                Just dropMeta ->
                     Sub.batch
                         [ Mouse.moves (wrap << Dragging)
-                        , Mouse.ups <| always <| onDrop drag.meta
+                        , Mouse.ups <| always <| onDrop dropMeta drag.dragMeta
                         , Mouse.ups (wrap << DragEnd)
                         ]
 
@@ -232,15 +228,15 @@ update msg model =
                     = DnD.update msg model.draggable }
 ``
 -}
-update : Msg a m -> Draggable a m -> Draggable a m
+update : Msg dropMeta dragMeta m -> Draggable dropMeta dragMeta m -> Draggable dropMeta dragMeta m
 update msg (Draggable model) =
     case msg of
-        DragStart meta xy ->
+        DragStart dragMeta xy ->
             Draggable <|
                 Just
-                    { meta = meta
+                    { dragMeta = dragMeta
                     , position = xy
-                    , atDroppable = Nothing
+                    , dropMeta = Nothing
                     }
 
         Dragging xy ->
@@ -251,18 +247,18 @@ update msg (Draggable model) =
         DragEnd xy ->
             Draggable Nothing
 
-        EnterDroppable onValidDrop ->
+        EnterDroppable dropMeta ->
             model
-                |> Maybe.map (\d -> { d | atDroppable = Just onValidDrop })
+                |> Maybe.map (\d -> { d | dropMeta = Just dropMeta })
                 |> Draggable
 
         LeaveDroppable ->
             model
-                |> Maybe.map (\d -> { d | atDroppable = Nothing })
+                |> Maybe.map (\d -> { d | dropMeta = Nothing })
                 |> Draggable
 
 
-draggable : (Msg a m -> m) -> a -> List (Html.Attribute m) -> List (Html m) -> Html m
+draggable : (Msg dropMeta dragMeta m -> m) -> dragMeta -> List (Html.Attribute m) -> List (Html m) -> Html m
 draggable wrap meta attrs html =
     div
         ([ onWithOptions "mousedown"
@@ -276,11 +272,11 @@ draggable wrap meta attrs html =
         html
 
 
-droppable : (Msg a m -> m) -> (a -> m) -> List (Html.Attribute m) -> List (Html m) -> Html m
-droppable wrap onDrop attrs html =
+droppable : (Msg dropMeta dragMeta m -> m) -> dropMeta -> List (Html.Attribute m) -> List (Html m) -> Html m
+droppable wrap dropMeta attrs html =
     div
         (attrs
-            ++ [ onMouseEnter (wrap <| EnterDroppable onDrop)
+            ++ [ onMouseEnter (wrap <| EnterDroppable dropMeta)
                , onMouseLeave (wrap LeaveDroppable)
                ]
         )
@@ -318,8 +314,8 @@ DnD.dragged
   box
 ```
 -}
-dragged : Draggable a m -> (a -> Html m) -> Html m
+dragged : Draggable dropMeta dragMeta m -> (dragMeta -> Html m) -> Html m
 dragged (Draggable model) view =
     model
-        |> Maybe.map (\{ meta, position } -> div [ draggedStyle position ] [ view meta ])
+        |> Maybe.map (\{ dragMeta, position } -> div [ draggedStyle position ] [ view dragMeta ])
         |> Maybe.withDefault (text "")


### PR DESCRIPTION
Previously, it had functions in both messages and model. This makes it hard to use the debugger, since you cannot serialize messages with functions in them.
Now, instead of only having meta for the draggable and a message creating function for the droppable, it's symmetric, so it has both dragMeta and dropMeta values.

To upgrade to the new API, make the following changes:
* Add a type parameter for the `dropMeta` to Dnd.Draggable and Dnd.Message and remove the `m` type parameter. If you don't care about the drop target, use the `()` type.
* Pass a message creation function `(dropMeta -> dragMeta -> Msg)` to `DnD.init` (probably a constructor for `Msg`). If you used the `()` type, pass `(always Dropped)` if you previously passed `Dropped` to the droppable function.
* replace `getMeta` with `getDragMeta`
* replace `atDroppable` with `getDropMeta` that returns a `(Maybe dropMeta)` instead of a `(Maybe Msg)`
* instead of passing a message creation function to the droppable function, pass a `dropMeta` value. If you used the `()` type, pass the `()` value.